### PR TITLE
Down to 50 max results, fix offset by 1 error max number

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -6,4 +6,4 @@ export POSTGRES_PORT=5432
 export POSTGRES_DB='register_data'
 export LOGGING_CONFIG_FILE_PATH='logging_config.json'
 export ELASTIC_SEARCH_ENDPOINT='http://localhost:9200'
-export MAX_NUMBER_SEARCH_RESULTS=200
+export MAX_NUMBER_SEARCH_RESULTS=50

--- a/service/server.py
+++ b/service/server.py
@@ -95,7 +95,7 @@ def create_search(doc_type):
     search = Search(
         using=client, index='landregistry', doc_type=doc_type)
     max_number = int(MAX_NUMBER_SEARCH_RESULTS)
-    search = search[0:max_number]
+    search = search[0:max_number-1]
     return search
 
 


### PR DESCRIPTION
This was including 201 elasticsearch results instead of 200. Offset now corrected. 