### PR TITLE
US119 - Set PYTHONPATH environment variable to application directory

### DIFF
--- a/environment.sh
+++ b/environment.sh
@@ -1,3 +1,4 @@
+#!/bin/sh
 export SETTINGS='dev'
 export POSTGRES_USER='postgres'
 export POSTGRES_PASSWORD='password'
@@ -7,3 +8,4 @@ export POSTGRES_DB='register_data'
 export LOGGING_CONFIG_FILE_PATH='logging_config.json'
 export ELASTIC_SEARCH_ENDPOINT='http://localhost:9200'
 export MAX_NUMBER_SEARCH_RESULTS=50
+export PYTHONPATH=.


### PR DESCRIPTION
This is needed to make sure gunicorn will locate settings file by relative path.