### PR TITLE
Fix bug in user_can_view with repeated purchases

### DIFF
--- a/service/db_access.py
+++ b/service/db_access.py
@@ -66,7 +66,7 @@ def user_can_view(user_id, title_number):
 
     # Get relevant record (only one assumed).
     kwargs = {"user_id": user_id, "title_number": title_number}
-    view = UserSearchAndResults.query.filter_by(**kwargs).first()
+    view = UserSearchAndResults.query.filter_by(**kwargs).order_by(UserSearchAndResults.viewed_datetime.desc().nullslast()).first()
 
     # 'viewed_datetime' denotes initial "access time" usage; name reflects different, earlier usage.
     if view and view.viewed_datetime and view.valid:


### PR DESCRIPTION
Fix bug in user_can_view whereby if you repeatedly purchase a title over a period longer than an hour, you can no longer view the title since it was validating based on your _first_ payment instead of your most recent one
